### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ You will need to update the your `ColdBox.cfc` with a `relax` structure with you
 ```
 relax = {
     // The location of the relaxed APIs, defaults to models.resources
-    APILocation = "models.resources",
+    APILocation = "modules.relax.models.resources",
     // Default API to load, name of the directory inside of resources
     defaultAPI = "myapi",
     // History stack size, the number of history items to track in the RelaxURL


### PR DESCRIPTION
If you are registering the module in the base Coldbox.cfc config it needs to have the full path of the module, otherwise a self-registering module only needs the "models.resources" path.