### PR TITLE
CF11 hack

### DIFF
--- a/modules/relax/ModuleConfig.cfc
+++ b/modules/relax/ModuleConfig.cfc
@@ -95,6 +95,7 @@ component{
 			try{
 				session["cbrelaxrandom"] = true;
 				sessionsEnabled = (isDefined("session"));
+				structDelete(session, "cbrelaxrandom");
 			}catch(Any e){
 				sessionsEnabled = false;
 			}

--- a/modules/relax/ModuleConfig.cfc
+++ b/modules/relax/ModuleConfig.cfc
@@ -88,12 +88,32 @@ component{
 		var configStruct 	= controller.getConfigSettings();
 
 		// Default Config Structure
-		configStruct.relax = {
-			APILocation 	= "#moduleMapping#.models.resources",
-			defaultAPI 		= "myapi",
-			maxHistory		= 10,
-			sessionsEnabled	= application.getApplicationSettings().sessionManagement
-		};
+
+		// CF11 hack (application.getApplicationSettings() info is not in struct format anymore, also no way to find out session management enabled or not )
+		if( (server.coldfusion.productname contains 'coldfusion') && ListFirst(server.coldfusion.productversion) == 11) {
+			var sessionsEnabled = true;
+			try{
+				session["cbrelaxrandom"] = true;
+				sessionsEnabled = (isDefined("session"));
+			}catch(Any e){
+				sessionsEnabled = false;
+			}
+
+			configStruct.relax = {
+				APILocation 	= "#moduleMapping#.models.resources",
+				defaultAPI 		= "myapi",
+				maxHistory		= 10,
+				sessionsEnabled	= sessionsEnabled
+			};
+		}
+		else{
+			configStruct.relax = {
+				APILocation 	= "#moduleMapping#.models.resources",
+				defaultAPI 		= "myapi",
+				maxHistory		= 10,
+				sessionsEnabled	= application.getApplicationSettings().sessionManagement
+			};
+		}
 
 		// Apend it
 		structAppend( configStruct.relax, relaxDSL, true );


### PR DESCRIPTION
`application.getApplicationSettings()` info is not in struct format anymore, also no way to find out session management enabled or not