### PR TITLE
Update the relax layout to be compatible between http and https

### DIFF
--- a/modules/relax/layouts/relax.cfm
+++ b/modules/relax/layouts/relax.cfm
@@ -16,8 +16,6 @@
     <title>ColdBox Relax - RESTful Tools For Lazy Experts</title>
     <!--- favicon --->
     <link href="#prc.root#/includes/images/favicon.ico" rel="shortcut icon" type="image/x-icon" />
-    <!--- SES --->
-	<base href="#getSetting( 'htmlBaseURL' )#" />
 	<!--- View Port --->
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <!-- Bootstrap core CSS -->
@@ -43,8 +41,8 @@
 	</cfloop>
 
     <!-- Fonts -->
-    <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,900,300italic,400italic,600italic,700italic,900italic' rel='stylesheet' type='text/css'>
-    <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700,900,300italic,400italic,600italic,700italic,900italic' rel='stylesheet' type='text/css'>
+    <link href='//fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
     <!-- Feature detection -->
     <script src="#prc.root#/includes/js/modernizr-2.6.2.min.js"></script>
     <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->


### PR DESCRIPTION
If the local dev environment is using simple http (without a certificate) and the same code gets pushed to Staging/Production, where a certificate is used then the layout doesn't work properly.
i.e. local: http://api.mysite.dev/relax
production: https://api.mysite.com/relax

From a https site you can call http, but not the other way around. Using "//" for URI links is a bit of an antipattern, but it works. You might think of a better solution.

I should give credit to my collegue, Richard Herbert (Richard #1 to Luis), who found this solution <-- smart guy!