### PR TITLE
Fix export as HTML

### DIFF
--- a/models/APIService.cfc
+++ b/models/APIService.cfc
@@ -146,8 +146,7 @@ component accessors="true" singleton {
 	function loadAPI( required name ){
         if ( arguments.name == "cbswagger" ) {
             variables.APIDefinitions[ arguments.name ] = wirebox.getInstance( "RoutesParser@cbswagger" )
-                .createDocFromRoutes()
-                .getNormalizedDocument();
+                .createDocFromRoutes();
         } else {
             var APIDirectory = variables.settings.APILocationExpanded & "/" & arguments.name & "/";
 

--- a/views/apidoc/cfTemplate/request-body.cfm
+++ b/views/apidoc/cfTemplate/request-body.cfm
@@ -4,13 +4,13 @@
 
 <cfloop array="#requestBody.content.keyArray()#" index="key">
 	<cfoutput>
-	<div id="#(entity["x-resourceId"] & '-requestBody-' & listLast( key, '/' ))#" class="method-card card card-info">
+	<div id="#(args.entity["x-resourceId"] & '-requestBody-' & listLast( key, '/' ))#" class="method-card card card-info">
 		<div class="card-header">
 			<h3 class="card-title methodHeader">
 				<strong>#key#</strong>
 			</h3>
 		</div>
-		<div id="card_#(entity["x-resourceId"] & '-requestBody-' & listLast( key, '/' ))#" class="card-body">
+		<div id="card_#(args.entity["x-resourceId"] & '-requestBody-' & listLast( key, '/' ))#" class="card-body">
 			<cfif structKeyExists( requestBody.content[ key ], "schema" ) && structKeyExists( requestBody.content[ key ].schema, "properties" )>
 			#renderView( view="apidoc/cfTemplate/schema", args={ "schema": requestBody.content[ key ].schema } )#
 			</cfif>


### PR DESCRIPTION
This pull request fixes 2 bugs that may occur when trying to export the API documentation as HTML (or MediaWiki, or TracMarkup).

1. variable [ENTITY] doesn't exist
   **How to reproduce:**
   Create a new ColdBox app with the `rest` template (Relax should come installed with this template):
   ```
   coldbox create app skeleton=rest
   ```
   Go to the Relax Petstore page (`/relax/api/petstore`) and click "Export as HTML" on the right sidebar. You will see the error:
   ![image](https://user-images.githubusercontent.com/53597966/126025470-4e3b8e75-d084-4c63-9266-a7b9aae2f3c9.png)

2. The function [getNormalizedDocument] does not exist
   **How to reproduce**
   Create a new ColdBox app with the `rest` template (like the 1st step).
   Go to the Relax cbswagger page (`/relax/api/cbswagger`) and click "Export as HTML" on the right sidebar. You will see the error:
   ![image](https://user-images.githubusercontent.com/53597966/126025531-19f3a96a-7fa2-40f9-afad-0dd58de3fa7a.png)
